### PR TITLE
Abriendo datos

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'jbuilder', '~> 2.0'
 gem 'foundation-rails'
 gem 'foundation_rails_helper'
 gem 'trix'
+gem 'tin_opener'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,8 @@ GEM
       activemodel (= 4.2.4)
       activesupport (= 4.2.4)
       arel (~> 6.0)
+    activerecord-import (0.10.0)
+      activerecord (>= 3.0)
     activesupport (4.2.4)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
@@ -152,6 +154,13 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (10.4.2)
     ref (2.0.0)
+    roo (2.1.1)
+      nokogiri (~> 1)
+      rubyzip (~> 1.1, < 2.0.0)
+    roo-xls (1.0.0)
+      nokogiri
+      roo (>= 2.0.0beta1, < 3)
+      spreadsheet (> 0.9.0)
     rspec (3.3.0)
       rspec-core (~> 3.3.0)
       rspec-expectations (~> 3.3.0)
@@ -173,7 +182,9 @@ GEM
       rspec-mocks (~> 3.3.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
+    ruby-ole (1.2.11.8)
     ruby-progressbar (1.7.5)
+    rubyzip (1.1.7)
     sass (3.4.19)
     sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
@@ -181,6 +192,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    spreadsheet (1.0.8)
+      ruby-ole (>= 1.0)
     spring (1.4.0)
     sprockets (3.4.0)
       rack (> 1, < 3)
@@ -198,6 +211,12 @@ GEM
     thread (0.2.2)
     thread_safe (0.3.5)
     tilt (2.0.1)
+    tin_opener (0.0.3)
+      activerecord-import (~> 0.10)
+      pg
+      rails (~> 4.2.4)
+      roo (~> 2.1)
+      roo-xls (~> 1.0)
     tins (1.6.0)
     trix (0.9.0)
       rails
@@ -243,6 +262,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   spring
   therubyracer
+  tin_opener
   trix
   turbolinks
   uglifier (>= 1.3.0)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   root 'home#index'
 
   resources :areas, only: [:index] do
-    resources :departments, only: [:index]  
+    resources :departments, only: [:index]
   end
   resources :departments, only: [:show]
   resources :objectives, only: [:show, :edit, :update]
@@ -11,4 +11,6 @@ Rails.application.routes.draw do
   get "designs/enquiry_index", to: "designs#enquiry_index"
   get "designs/enquiry_form", to: "designs#enquiry_form"
   get "designs/enquiry_show", to: "designs#enquiry_show"
+
+  mount TinOpener::Engine => "/tin_opener"
 end

--- a/db/migrate/20151026000346_enable_hstore.tin_opener.rb
+++ b/db/migrate/20151026000346_enable_hstore.tin_opener.rb
@@ -1,0 +1,6 @@
+# This migration comes from tin_opener (originally 20151024183112)
+class EnableHstore < ActiveRecord::Migration
+  def change
+    enable_extension 'hstore' unless extension_enabled?('hstore')
+  end
+end

--- a/db/migrate/20151026000347_create_tin_opener_data_sets.tin_opener.rb
+++ b/db/migrate/20151026000347_create_tin_opener_data_sets.tin_opener.rb
@@ -1,0 +1,11 @@
+# This migration comes from tin_opener (originally 20151024183219)
+class CreateTinOpenerDataSets < ActiveRecord::Migration
+  def change
+    create_table :tin_opener_data_sets do |t|
+      t.string :name
+      t.hstore :headers
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20151026000348_create_tin_opener_records.tin_opener.rb
+++ b/db/migrate/20151026000348_create_tin_opener_records.tin_opener.rb
@@ -1,0 +1,11 @@
+# This migration comes from tin_opener (originally 20151024194928)
+class CreateTinOpenerRecords < ActiveRecord::Migration
+  def change
+    create_table :tin_opener_records do |t|
+      t.hstore :row_data
+      t.belongs_to :data_set
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151025144106) do
+ActiveRecord::Schema.define(version: 20151026000348) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "hstore"
 
   create_table "areas", force: :cascade do |t|
     t.string "name"
@@ -44,6 +45,20 @@ ActiveRecord::Schema.define(version: 20151025144106) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "parent_id"
+  end
+
+  create_table "tin_opener_data_sets", force: :cascade do |t|
+    t.string   "name"
+    t.hstore   "headers"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "tin_opener_records", force: :cascade do |t|
+    t.hstore   "row_data"
+    t.integer  "data_set_id"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
   end
 
 end


### PR DESCRIPTION
Addresses #9 - esta PR es WIP 
- [X] Por motivos administrativos el backend debe ser PostgreSQL (es posible hacer uso de configuraciones avanzadas de postgresql como hstore)
- [X] Los administradores deben poder subir tipos de ficheros nuevos sin tener que pedir a los desarrolladores que implementen un modelo nuevo a medida para cada tipo.
- [X] Los datos importados deberán tener un "tipo" 
- [ ] Al importar el fichero se podrá utilizar un tipo ya existente o crear uno nuevo.
- [ ] Si se importan datos de tipos ya existentes, la página debe chequear que las columnas de los nuevos datos coinciden con las existentes.
- [ ] Los datos obtenidos deben después poder ser mostrados descargados al menos en csv.
- [ ] Idealmente, las páginas informativas ( #8 ) deberían poder listar al menos los registros de una categoría en formato tabla.
- [X] Soporte para CSV, XLS y XLST.
- [ ] Integridad de datos: una línea en blanco debería ser ignorada, una línea mal formada debería dar un error.
- [ ] Rake task para cargar datos por consola.

Extras:
- [ ] Idealmente los administradores tendrían que poder editar los datos tabulados (por ejemplo para eliminar duplicados)
- [ ] Punto extra si se guarda la metainformación relativa a quién y cuándo hizo la importación/modificación de cada registro.
- [X] Punto extra si se desarrolla como gema independiente, que se pueda incluir en otros proyectos fácilmente.

Para probarlo, en `/tin_opener/` hay una interfaz de carga y edición de datos muy preliminar y sin estilos.

¿Opiniones?
