### PR TITLE
Update sass-rails to avoid sprockets deprecation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'rails', '4.2.7.1'
 # Use PostgreSQL
 gem 'pg'
 # Use SCSS for stylesheets
-gem 'sass-rails', '~> 5.0'
+gem 'sass-rails', '~> 5.0.6'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
 # Use CoffeeScript for .coffee assets and views

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -243,8 +243,8 @@ GEM
     ruby-progressbar (1.7.5)
     rubyzip (1.2.1)
     sass (3.4.21)
-    sass-rails (5.0.4)
-      railties (>= 4.0.0, < 5.0)
+    sass-rails (5.0.6)
+      railties (>= 4.0.0, < 6)
       sass (~> 3.1)
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
@@ -341,7 +341,7 @@ DEPENDENCIES
   roo
   roo-xls
   rspec-rails (~> 3.0)
-  sass-rails (~> 5.0)
+  sass-rails (~> 5.0.6)
   spreadsheet
   spring
   therubyracer


### PR DESCRIPTION
## What

Running the tests we get:
```
DEPRECATION WARNING: Sprockets method `register_engine` is deprecated.
Please register a mime type using `register_mime_type` then
use `register_compressor` or `register_transformer`.
https://github.com/rails/sprockets/blob/master/guides/extending_sprockets.md#supporting-all-versions-of-sprockets-in-processors
 (called from block (2 levels) in <class:Railtie> at /Users/bertocq/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/sass-rails-5.0.4/lib/sass/rails/railtie.rb:57)
DEPRECATION WARNING: Sprockets method `register_engine` is deprecated.
Please register a mime type using `register_mime_type` then
use `register_compressor` or `register_transformer`.
https://github.com/rails/sprockets/blob/master/guides/extending_sprockets.md#supporting-all-versions-of-sprockets-in-processors
 (called from block (2 levels) in <class:Railtie> at /Users/bertocq/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/sass-rails-5.0.4/lib/sass/rails/railtie.rb:58)
```

As read at https://stackoverflow.com/questions/38515972/rails-4-rake-command-shows-deprecation-warning-everytime-i-run-the-rake-dbmig

```
This is caused by Sprockets 3.7.0 and should be fixed in sass-rails (which uses Sprockets) shortly. See this for more information.
...
This is now fixed in sass-rails version 5.0.6. Running bundle update should remove the deprecation warnings.
```

## How
Just upgrading sass-rails gem from 5.0 to 5.0.6