### PR TITLE
Upgrade roo-xls version to 1.1 to avoid deprecation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,8 +31,8 @@ gem 'dalli'
 gem 'rollbar', '~> 2.8.3'
 gem 'newrelic_rpm', '~> 3.14'
 gem 'rinku', require: 'rails_rinku'
-gem 'roo'
-gem 'roo-xls'
+gem 'roo', '~> 2.7'
+gem 'roo-xls', '~> 1.1'
 gem 'spreadsheet'
 gem 'whenever', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,7 +214,7 @@ GEM
     roo (2.7.1)
       nokogiri (~> 1)
       rubyzip (~> 1.1, < 2.0.0)
-    roo-xls (1.0.0)
+    roo-xls (1.1.0)
       nokogiri
       roo (>= 2.0.0beta1, < 3)
       spreadsheet (> 0.9.0)
@@ -338,8 +338,8 @@ DEPENDENCIES
   rails (= 4.2.7.1)
   rinku
   rollbar (~> 2.8.3)
-  roo
-  roo-xls
+  roo (~> 2.7)
+  roo-xls (~> 1.1)
   rspec-rails (~> 3.0)
   sass-rails (~> 5.0.6)
   spreadsheet
@@ -354,4 +354,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.14.6
+   1.15.0


### PR DESCRIPTION
## What
Running specs throwed deprecation warnings: [`[DEPRECATION]`extend Roo::Tempdir and use its .make_tempdir instead](https://github.com/roo-rb/roo-xls/issues/28). Those are fixed on the next roo-xls version [1.1.0](https://github.com/roo-rb/roo-xls/releases), and currently 1.0.0 was being used.

## How
- Specify roo-xls version in Gemfile to 1.1
- Also set roo version to 2.7 (currently used on Gemfile.lock, and also latest release)
