### PR TITLE
Add editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig is awesome: http://EditorConfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
[Editorconfig](http://editorconfig.org/) helps developers define and maintain consistent coding styles between different editors and IDEs.

If the contributor has a [plugin](http://editorconfig.org/#download) on his editor/IDE, it will autocorrect inconsistencies... if not there won't be any issues. So its this file will just help those that care about following agreed configurations. Note: Some editors like RubyMine have the plugin installed by default.

I agree maybe the `insert_final_newline` it's something to discuss about, but I'm just reusing the [example](http://editorconfig.org/#example-file), also at any project I've been it hasn't created any mayor issues.