### PR TITLE
Fix/declarations initial period

### DIFF
--- a/app/controllers/admin/activities_uploads_controller.rb
+++ b/app/controllers/admin/activities_uploads_controller.rb
@@ -2,9 +2,12 @@ require 'stringio'
 require 'logger'
 require 'excel_importers/activities'
 
+include DeclarationsHelper
+
 class Admin::ActivitiesUploadsController < Admin::BaseController
   def new
     @activities_upload = ActivitiesUpload.new
+    @periods_list = DeclarationsHelper.periods_list
   end
 
   def index
@@ -13,7 +16,7 @@ class Admin::ActivitiesUploadsController < Admin::BaseController
 
   def create
     attrs = activities_upload_params.merge(author: current_administrator,
-                                        check_for_file: true)
+                                           check_for_file: true)
     @activities_upload = ActivitiesUpload.new(attrs)
 
     if @activities_upload.valid?
@@ -56,4 +59,6 @@ class Admin::ActivitiesUploadsController < Admin::BaseController
     def activities_upload_params
       params.require(:activities_upload).permit(:file, :period)
     end
+
+    def periods_list; end
 end

--- a/app/controllers/admin/assets_uploads_controller.rb
+++ b/app/controllers/admin/assets_uploads_controller.rb
@@ -1,10 +1,12 @@
 require 'stringio'
 require 'logger'
 require 'excel_importers/assets'
+include DeclarationsHelper
 
 class Admin::AssetsUploadsController < Admin::BaseController
   def new
     @assets_upload = AssetsUpload.new
+    @periods_list = DeclarationsHelper.periods_list
   end
 
   def index
@@ -13,15 +15,15 @@ class Admin::AssetsUploadsController < Admin::BaseController
 
   def create
     attrs = assets_upload_params.merge(author: current_administrator,
-                                        check_for_file: true)
+                                       check_for_file: true)
     @assets_upload = AssetsUpload.new(attrs)
 
     if @assets_upload.valid?
       StringIO.open do |strio|
         logger = ExcelImporters::Base.new_default_logger(strio)
         importer = ExcelImporters::Assets.new @assets_upload.file.tempfile,
-                                                  @assets_upload.period,
-                                                  logger
+                                              @assets_upload.period,
+                                              logger
         successful = true
         if importer.import
           flash[:notice] = t('admin.assets_uploads.create.no_errors')

--- a/app/helpers/declarations_helper.rb
+++ b/app/helpers/declarations_helper.rb
@@ -1,0 +1,14 @@
+include ActionView::Helpers::TranslationHelper
+
+module DeclarationsHelper
+
+  PERIODS_START_YEAR = 2016
+
+  def periods_list
+    initial = { initial: t('initial') }
+    years = Hash[(PERIODS_START_YEAR..Date.current.year + 1).map { |year| [year, year] }]
+    final = { final: t('final') }
+    initial.merge(years).merge(final)
+  end
+
+end

--- a/app/views/admin/activities_uploads/new.html.erb
+++ b/app/views/admin/activities_uploads/new.html.erb
@@ -3,7 +3,7 @@
 <%= form_for @activities_upload, url: admin_activities_uploads_path do |f| %>
   <%= f.hidden_field :id %>
   <%= f.file_field :file %>
-  <%= f.collection_select :period, %w{inicial 2016 2017 2018 2019 2020 2021 2022 final}, :to_s, :to_s, include_blank: true %>
+  <%= f.collection_select :period, @periods_list, :first, :last, include_blank: true %>
   <%= f.submit(class: "button radius", value: t("shared.submit")) %>
 <% end %>
 

--- a/app/views/admin/assets_uploads/new.html.erb
+++ b/app/views/admin/assets_uploads/new.html.erb
@@ -3,7 +3,7 @@
 <%= form_for @assets_upload, url: admin_assets_uploads_path do |f| %>
   <%= f.hidden_field :id %>
   <%= f.file_field :file %>
-  <%= f.collection_select :period, %w{inicial 2016 2017 2018 2019 2020 2021 2022 final}, :to_s, :to_s, include_blank: true %>
+  <%= f.collection_select :period, @periods_list, :first, :last, include_blank: true %>
   <%= f.submit(class: "button radius", value: t("shared.submit")) %>
 <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,6 +4,8 @@ en:
   booleans:
     t: "Yes"
     f: "No"
+  initial: 'initial'
+  final: 'final'
   admin:
     menu:
       title: "Administration"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -348,7 +348,7 @@ en:
     form:
       save: Save
   activities_declarations:
-    initial: "First"
+    initial: "Initial"
     yearly: "Yearly %{year}"
     final: "Final"
     date: "Declaration date: %{date}"
@@ -372,7 +372,7 @@ en:
       start_date: "Start date"
       end_date: "End date"
   assets_declarations:
-    initial: "First"
+    initial: "Initial"
     yearly: "Yearly %{year}"
     final: "Final"
     date: "Declaration date: %{date}"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -4,6 +4,8 @@ es:
   booleans:
     t: "Sí"
     f: "No"
+  initial: 'inicial'
+  final: 'final'
   admin:
     menu:
       title: "Administración"

--- a/spec/features/admin/activities_uploads_spec.rb
+++ b/spec/features/admin/activities_uploads_spec.rb
@@ -23,7 +23,7 @@ feature 'Admin Activities Uploads' do
   end
 
   scenario 'Administrator can upload correct xls files' do
-    create(:person, personal_code: 5697, first_name: "Pepe", last_name: "Lopez")
+    person = create(:person, personal_code: 5697, first_name: "Pepe", last_name: "Lopez")
     login_as create(:administrator)
     visit admin_root_path
 
@@ -31,7 +31,7 @@ feature 'Admin Activities Uploads' do
     click_link 'Upload a new file'
 
     attach_file('activities_upload_file', Rails.root.join('spec/fixtures/files/single_activities.xls'))
-    page.select('inicial', from: 'activities_upload_period')
+    page.select('initial', from: 'activities_upload_period')
 
     click_button 'Submit'
 
@@ -39,6 +39,9 @@ feature 'Admin Activities Uploads' do
     expect(page).to have_content 'File format: xls'
     expect(page).to have_content 'File processed successfully'
     expect(page).to have_content 'Activity declaration for Pepe Lopez'
+
+    visit person_path(person)
+    expect(page).to have_content 'Initial'
   end
 
   scenario 'Administrator can upload xls file with error' do
@@ -49,7 +52,7 @@ feature 'Admin Activities Uploads' do
     click_link 'Upload a new file'
 
     attach_file('activities_upload_file', Rails.root.join('spec/fixtures/files/single_activities.xls'))
-    page.select('inicial', from: 'activities_upload_period')
+    page.select('initial', from: 'activities_upload_period')
 
     click_button 'Submit'
 
@@ -65,7 +68,7 @@ feature 'Admin Activities Uploads' do
     click_link 'Upload a new file'
 
     attach_file('activities_upload_file', Rails.root.join('spec/fixtures/files/banana.gif'))
-    page.select('inicial', from: 'activities_upload_period')
+    page.select('initial', from: 'activities_upload_period')
     click_button 'Submit'
 
     expect(page).to have_content 'Errors were detected while processing the file'

--- a/spec/features/admin/assets_uploads_spec.rb
+++ b/spec/features/admin/assets_uploads_spec.rb
@@ -23,7 +23,7 @@ feature 'Admin Assets Uploads' do
   end
 
   scenario 'Administrator can upload correct xls files' do
-    create(:person, personal_code: 2379, first_name: "Pepe", last_name: "Lopez")
+    person = create(:person, personal_code: 2379, first_name: "Pepe", last_name: "Lopez")
     login_as create(:administrator)
     visit admin_root_path
 
@@ -31,7 +31,7 @@ feature 'Admin Assets Uploads' do
     click_link 'Upload a new file'
 
     attach_file('assets_upload_file', Rails.root.join('spec/fixtures/files/single_assets.xls'))
-    page.select('inicial', from: 'assets_upload_period')
+    page.select('initial', from: 'assets_upload_period')
 
     click_button 'Submit'
 
@@ -39,6 +39,9 @@ feature 'Admin Assets Uploads' do
     expect(page).to have_content 'File format: xls'
     expect(page).to have_content 'File processed successfully'
     expect(page).to have_content 'Assets declaration for Pepe Lopez'
+
+    visit person_path(person)
+    expect(page).to have_content 'Initial'
   end
 
   scenario 'Administrator can upload xls file with error' do
@@ -49,7 +52,7 @@ feature 'Admin Assets Uploads' do
     click_link 'Upload a new file'
 
     attach_file('assets_upload_file', Rails.root.join('spec/fixtures/files/single_assets.xls'))
-    page.select('inicial', from: 'assets_upload_period')
+    page.select('initial', from: 'assets_upload_period')
 
     click_button 'Submit'
 
@@ -65,7 +68,7 @@ feature 'Admin Assets Uploads' do
     click_link 'Upload a new file'
 
     attach_file('assets_upload_file', Rails.root.join('spec/fixtures/files/banana.gif'))
-    page.select('inicial', from: 'assets_upload_period')
+    page.select('initial', from: 'assets_upload_period')
     click_button 'Submit'
 
     expect(page).to have_content 'Errors were detected while processing the file'


### PR DESCRIPTION
## What
We where using "inicial" as both value and label on declarations periods list. That was causing any initial declaration not to get recognized as initial because 'inicial' != 'initial' and english vale was the one used to check at models https://github.com/AyuntamientoMadrid/transparencia/blob/fix/declarations_initial_period/app/models/activities_declaration.rb#L14

## How
Composing correctly the list of values and labels for the periods list offered on both activities and assets declaration's upload admin page. 

Using translations to correctly get always 'initial' as the value, regardless of the label the current localization uses.

## Test
Increased to check the councillor's page to findout the new period title on both declarations

## Depoyment
Asap to staging servers for testing

## Warnings
None